### PR TITLE
飞书API参数命名优化与文档更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@
   - [运行服务](#运行服务)
 - [配置说明](#配置说明)
 - [API文档](#api文档)
+  - [搜索操作](#搜索操作)
   - [文档操作](#文档操作)
   - [机器人操作](#机器人操作)
   - [聊天操作](#聊天操作)
   - [多维表格操作](#多维表格操作)
+  - [用户操作](#用户操作)
+  - [部门操作](#部门操作)
+  - [日历操作](#日历操作)
+  - [任务操作](#任务操作)
 - [开发指南](#开发指南)
   - [代码规范](#代码规范)
   - [错误处理](#错误处理)
@@ -194,6 +199,46 @@ node dist/index.js --stdio
 
 ## API文档
 
+### 搜索操作
+
+#### `search_feishu_users`
+
+搜索飞书用户。
+
+参数：
+- `query` - 搜索关键词
+- `pageSize` - 每页返回的用户数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 搜索结果用户列表（JSON格式）
+
+#### `search_feishu_messages`
+
+搜索飞书消息。
+
+参数：
+- `query` - 搜索关键词
+- `messageType` - 消息类型，可选，如'text'、'interactive'等
+- `pageSize` - 每页返回的消息数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 搜索结果消息列表（JSON格式）
+
+#### `search_feishu_docs`
+
+搜索飞书文档。
+
+参数：
+- `query` - 搜索关键词
+- `type` - 文档类型，可选，如'docx'、'sheet'等
+- `pageSize` - 每页返回的文档数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 搜索结果文档列表（JSON格式）
+
 ### 文档操作
 
 #### `get_feishu_doc_raw`
@@ -216,6 +261,54 @@ node dist/index.js --stdio
 返回：
 - 文档的元数据（JSON格式）
 
+#### `update_feishu_doc`
+
+更新飞书文档内容。
+
+参数：
+- `docId` - 文档ID
+- `content` - 新的文档内容
+- `revision` - 文档修订版本号，可选
+
+返回：
+- 更新状态和文档信息
+
+#### `delete_feishu_doc`
+
+删除飞书文档。
+
+参数：
+- `docId` - 文档ID
+
+返回：
+- 删除状态
+
+#### `get_feishu_doc_blocks`
+
+获取飞书文档的块内容。
+
+参数：
+- `docId` - 文档ID
+- `blockId` - 块ID，可选，不提供时获取所有块
+- `pageSize` - 每页返回的块数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 文档块列表（JSON格式）
+
+#### `search_feishu_docs`
+
+搜索飞书文档。
+
+参数：
+- `query` - 搜索关键词
+- `type` - 文档类型，可选，如'docx'、'sheet'等
+- `pageSize` - 每页返回的文档数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 搜索结果文档列表（JSON格式）
+
 ### 机器人操作
 
 #### `send_feishu_text_message`
@@ -223,8 +316,9 @@ node dist/index.js --stdio
 发送文本消息到飞书聊天。
 
 参数：
-- `chatId` - 聊天ID
+- `receiveId` - 接收者ID
 - `text` - 要发送的文本内容
+- `receiveIdType` - 接收者ID类型，可选值：'chat_id'(默认)、'open_id'、'user_id'、'union_id'、'email'
 
 返回：
 - 发送状态和消息ID
@@ -234,11 +328,60 @@ node dist/index.js --stdio
 发送交互卡片到飞书聊天。
 
 参数：
-- `chatId` - 聊天ID
+- `receiveId` - 接收者ID
 - `cardContent` - 卡片内容（JSON字符串）
+- `receiveIdType` - 接收者ID类型，可选值：'chat_id'(默认)、'open_id'、'user_id'、'union_id'、'email'
 
 返回：
 - 发送状态和消息ID
+
+#### `reply_feishu_message`
+
+回复飞书消息。
+
+参数：
+- `messageId` - 要回复的消息ID
+- `content` - 回复内容
+- `msgType` - 消息类型，可选值：'text'、'interactive'等
+
+返回：
+- 发送状态和消息ID
+
+#### `edit_feishu_message`
+
+编辑飞书消息。
+
+参数：
+- `messageId` - 要编辑的消息ID
+- `content` - 新的消息内容
+- `msgType` - 消息类型，可选值：'text'、'interactive'等
+
+返回：
+- 更新状态和消息ID
+
+#### `forward_feishu_message`
+
+转发飞书消息。
+
+参数：
+- `messageId` - 要转发的消息ID
+- `receiveId` - 接收者ID
+- `receiveIdType` - 接收者ID类型，可选值：'chat_id'(默认)、'open_id'、'user_id'、'union_id'、'email'
+
+返回：
+- 转发状态和新消息ID
+
+#### `get_feishu_message_read_users`
+
+获取已读消息的用户列表。
+
+参数：
+- `messageId` - 消息ID
+- `pageSize` - 每页返回的用户数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 已读用户列表（JSON格式）
 
 ### 聊天操作
 
@@ -251,6 +394,171 @@ node dist/index.js --stdio
 
 返回：
 - 聊天的基本信息（JSON格式）
+
+#### `create_feishu_chat`
+
+创建飞书群聊。
+
+参数：
+- `name` - 群名称
+- `description` - 群描述，可选
+- `userIds` - 用户ID列表，群成员
+
+返回：
+- 创建的群聊信息（JSON格式）
+
+#### `update_feishu_chat`
+
+更新飞书群聊信息。
+
+参数：
+- `chatId` - 聊天ID
+- `name` - 新的群名称，可选
+- `description` - 新的群描述，可选
+
+返回：
+- 更新状态
+
+#### `add_feishu_chat_members`
+
+添加成员到飞书群聊。
+
+参数：
+- `chatId` - 聊天ID
+- `userIds` - 要添加的用户ID列表
+
+返回：
+- 添加状态和结果信息
+
+#### `remove_feishu_chat_members`
+
+从飞书群聊中移除成员。
+
+参数：
+- `chatId` - 聊天ID
+- `userIds` - 要移除的用户ID列表
+
+返回：
+- 移除状态和结果信息
+
+### 用户操作
+
+#### `get_feishu_user_info`
+
+获取飞书用户信息。
+
+参数：
+- `userId` - 用户ID
+- `userIdType` - 用户ID类型，可选值：'open_id'(默认)、'union_id'、'user_id'、'email'
+
+返回：
+- 用户信息（JSON格式），包含用户ID、姓名、头像、部门等信息
+
+#### `list_feishu_users`
+
+获取飞书用户列表。
+
+参数：
+- `departmentId` - 部门ID，可选，指定获取某个部门的用户
+- `pageSize` - 每页返回的用户数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 用户列表（JSON格式），包含用户ID、姓名、头像、部门等信息
+
+#### `search_feishu_users`
+
+搜索飞书用户。
+
+参数：
+- `query` - 搜索关键词
+- `pageSize` - 每页返回的用户数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 搜索结果用户列表（JSON格式）
+
+### 部门操作
+
+#### `get_feishu_department_info`
+
+获取飞书部门信息。
+
+参数：
+- `departmentId` - 部门ID
+- `departmentIdType` - 部门ID类型，可选值：'open_department_id'(默认)、'department_id'
+
+返回：
+- 部门信息（JSON格式），包含部门ID、名称、父部门、成员数量等信息
+
+#### `list_feishu_departments`
+
+获取飞书部门列表。
+
+参数：
+- `parentDepartmentId` - 父部门ID，可选，指定获取某个部门的子部门
+- `fetchChild` - 是否获取子部门，可选，默认为false
+- `pageSize` - 每页返回的部门数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 部门列表（JSON格式），包含部门ID、名称、父部门、成员数量等信息
+
+### 日历操作
+
+#### `list_feishu_calendars`
+
+获取飞书日历列表。
+
+参数：
+- `pageSize` - 每页返回的日历数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 日历列表（JSON格式），包含日历ID、名称、类型、权限等信息
+
+#### `get_feishu_calendar_events`
+
+获取飞书日历事件。
+
+参数：
+- `calendarId` - 日历ID
+- `startTime` - 开始时间，ISO 8601格式
+- `endTime` - 结束时间，ISO 8601格式
+- `pageSize` - 每页返回的事件数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 日历事件列表（JSON格式），包含事件ID、标题、时间、地点、参与者等信息
+
+### 任务操作
+
+#### `list_feishu_tasks`
+
+获取飞书任务列表。
+
+参数：
+- `taskListId` - 任务列表ID，可选
+- `completedTaskHiddenMode` - 已完成任务的隐藏模式，可选值：'show_all'、'hide_all'
+- `pageSize` - 每页返回的任务数量，可选，默认为20
+- `pageToken` - 分页标记，可选，用于获取下一页数据
+
+返回：
+- 任务列表（JSON格式），包含任务ID、标题、描述、截止时间、完成状态等信息
+
+#### `create_feishu_task`
+
+创建飞书任务。
+
+参数：
+- `taskListId` - 任务列表ID
+- `summary` - 任务标题
+- `description` - 任务描述，可选
+- `due` - 截止时间，ISO 8601格式，可选
+- `origin` - 任务来源，可选
+
+返回：
+- 创建的任务信息（JSON格式），包含任务ID、标题、描述、截止时间等信息
 
 ### 多维表格操作
 
@@ -330,6 +638,43 @@ node dist/index.js --stdio
 
 返回：
 - 单条记录（JSON格式），包含记录ID和字段值
+
+#### `create_feishu_sheet_record`
+
+在飞书多维表格中创建新记录。
+
+参数：
+- `appToken` - 多维表格ID，通常在URL中找到 (例如：feishu.cn/base/<appToken> 或 feishu.cn/app/<appToken>)
+- `tableId` - 数据表ID
+- `fields` - 字段值，JSON对象，键为字段ID，值为字段值
+
+返回：
+- 创建的记录信息（JSON格式），包含记录ID
+
+#### `update_feishu_sheet_record`
+
+更新飞书多维表格中的记录。
+
+参数：
+- `appToken` - 多维表格ID，通常在URL中找到 (例如：feishu.cn/base/<appToken> 或 feishu.cn/app/<appToken>)
+- `tableId` - 数据表ID
+- `recordId` - 记录ID
+- `fields` - 字段值，JSON对象，键为字段ID，值为字段值
+
+返回：
+- 更新状态和记录信息
+
+#### `delete_feishu_sheet_record`
+
+删除飞书多维表格中的记录。
+
+参数：
+- `appToken` - 多维表格ID，通常在URL中找到 (例如：feishu.cn/base/<appToken> 或 feishu.cn/app/<appToken>)
+- `tableId` - 数据表ID
+- `recordId` - 记录ID
+
+返回：
+- 删除状态
 
 ## 开发指南
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
-/** @type {import('jest').Config} */
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
@@ -10,5 +9,5 @@ module.exports = {
     '^.+\\.(js|jsx)$': 'babel-jest',
   },
   transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
-  testMatch: ['**/task-simple.test.js'],
+  testMatch: ['**/tests/**/*.test.js'],
 };

--- a/src/client/bots/bot-client.ts
+++ b/src/client/bots/bot-client.ts
@@ -26,14 +26,14 @@ export class BotClient extends ApiClient {
   /**
    * Send message to a chat
    *
-   * @param chatId - Chat ID
+   * @param receiveId - Receive ID
    * @param content - Message content
    * @param msgType - Message type
    * @param receiveIdType - Type of the receive ID, defaults to 'chat_id'
    * @returns Message response with ID
    */
   sendMessage = (
-    chatId: string,
+    receiveId: string,
     content: string | Record<string, unknown>,
     msgType: MessageType,
     receiveIdType = 'chat_id',
@@ -54,7 +54,7 @@ export class BotClient extends ApiClient {
     return this.post<MessageResponse>(
       '/open-apis/im/v1/messages',
       {
-        receive_id: chatId,
+        receive_id: receiveId,
         content: JSON.stringify(formattedContent),
         msg_type: msgType,
       },

--- a/src/client/bots/bot-client.ts
+++ b/src/client/bots/bot-client.ts
@@ -29,12 +29,14 @@ export class BotClient extends ApiClient {
    * @param chatId - Chat ID
    * @param content - Message content
    * @param msgType - Message type
+   * @param receiveIdType - Type of the receive ID, defaults to 'chat_id'
    * @returns Message response with ID
    */
   sendMessage = (
     chatId: string,
     content: string | Record<string, unknown>,
     msgType: MessageType,
+    receiveIdType = 'chat_id',
   ): Promise<ApiResponse<MessageResponse>> => {
     let formattedContent: Record<string, unknown>;
 
@@ -56,7 +58,7 @@ export class BotClient extends ApiClient {
         content: JSON.stringify(formattedContent),
         msg_type: msgType,
       },
-      { receive_id_type: 'chat_id' },
+      { receive_id_type: receiveIdType },
     );
   };
 

--- a/src/server/tools/bot-tools.ts
+++ b/src/server/tools/bot-tools.ts
@@ -33,11 +33,20 @@ export function registerBotTools(params: ToolRegistryParams): void {
     {
       chatId: z.string().describe('The chat ID to send the message to'),
       text: z.string().describe('The text content of the message'),
+      receiveIdType: z
+        .enum(['open_id', 'union_id', 'user_id', 'email', 'chat_id'])
+        .optional()
+        .default('chat_id')
+        .describe('Type of the receive ID, defaults to chat_id'),
     },
-    async ({ chatId, text }) => {
+    async ({ chatId, text, receiveIdType }) => {
       try {
         logger.info(`Sending message to chat ${chatId}`);
-        const messageId = await services.bots.sendTextMessage(chatId, text);
+        const messageId = await services.bots.sendTextMessage(
+          chatId,
+          text,
+          receiveIdType,
+        );
 
         return {
           content: [
@@ -69,8 +78,13 @@ export function registerBotTools(params: ToolRegistryParams): void {
     {
       chatId: z.string().describe('The chat ID to send the card to'),
       cardContent: z.string().describe('The card content as JSON string'),
+      receiveIdType: z
+        .enum(['open_id', 'union_id', 'user_id', 'email', 'chat_id'])
+        .optional()
+        .default('chat_id')
+        .describe('Type of the receive ID, defaults to chat_id'),
     },
-    async ({ chatId, cardContent }) => {
+    async ({ chatId, cardContent, receiveIdType }) => {
       try {
         let cardJson: Record<string, unknown>;
 
@@ -89,7 +103,11 @@ export function registerBotTools(params: ToolRegistryParams): void {
         }
 
         logger.info(`Sending card to chat ${chatId}`);
-        const messageId = await services.bots.sendCardMessage(chatId, cardJson);
+        const messageId = await services.bots.sendCardMessage(
+          chatId,
+          cardJson,
+          receiveIdType,
+        );
 
         return {
           content: [

--- a/src/server/tools/bot-tools.ts
+++ b/src/server/tools/bot-tools.ts
@@ -31,7 +31,7 @@ export function registerBotTools(params: ToolRegistryParams): void {
     TOOL_SEND_TEXT_MESSAGE,
     'Send a text message to a FeiShu chat via bot',
     {
-      chatId: z.string().describe('The chat ID to send the message to'),
+      receiveId: z.string().describe('The ID to send the message to'),
       text: z.string().describe('The text content of the message'),
       receiveIdType: z
         .enum(['open_id', 'union_id', 'user_id', 'email', 'chat_id'])
@@ -39,11 +39,11 @@ export function registerBotTools(params: ToolRegistryParams): void {
         .default('chat_id')
         .describe('Type of the receive ID, defaults to chat_id'),
     },
-    async ({ chatId, text, receiveIdType }) => {
+    async ({ receiveId, text, receiveIdType }) => {
       try {
-        logger.info(`Sending message to chat ${chatId}`);
+        logger.info(`Sending message to ${receiveId}`);
         const messageId = await services.bots.sendTextMessage(
-          chatId,
+          receiveId,
           text,
           receiveIdType,
         );
@@ -76,7 +76,7 @@ export function registerBotTools(params: ToolRegistryParams): void {
     TOOL_SEND_CARD,
     'Send an interactive card to a FeiShu chat',
     {
-      chatId: z.string().describe('The chat ID to send the card to'),
+      receiveId: z.string().describe('The ID to send the card to'),
       cardContent: z.string().describe('The card content as JSON string'),
       receiveIdType: z
         .enum(['open_id', 'union_id', 'user_id', 'email', 'chat_id'])
@@ -84,7 +84,7 @@ export function registerBotTools(params: ToolRegistryParams): void {
         .default('chat_id')
         .describe('Type of the receive ID, defaults to chat_id'),
     },
-    async ({ chatId, cardContent, receiveIdType }) => {
+    async ({ receiveId, cardContent, receiveIdType }) => {
       try {
         let cardJson: Record<string, unknown>;
 
@@ -102,9 +102,9 @@ export function registerBotTools(params: ToolRegistryParams): void {
           };
         }
 
-        logger.info(`Sending card to chat ${chatId}`);
+        logger.info(`Sending card to ${receiveId}`);
         const messageId = await services.bots.sendCardMessage(
-          chatId,
+          receiveId,
           cardJson,
           receiveIdType,
         );

--- a/src/services/bots/bot-service.ts
+++ b/src/services/bots/bot-service.ts
@@ -28,17 +28,20 @@ export class BotService {
    *
    * @param chatId - Chat ID
    * @param text - Message text
+   * @param receiveIdType - Type of the receive ID, defaults to 'chat_id'
    * @returns Message ID
    */
   async sendTextMessage(
     chatId: string,
     text: string,
+    receiveIdType = 'chat_id',
   ): Promise<BotMessageResponseBO> {
     try {
       const response = await this.client.sendMessage(
         chatId,
         text,
         MessageType.TEXT,
+        receiveIdType,
       );
 
       if (response.code !== 0) {
@@ -71,17 +74,20 @@ export class BotService {
    *
    * @param chatId - Chat ID
    * @param cardContent - Interactive card JSON content
+   * @param receiveIdType - Type of the receive ID, defaults to 'chat_id'
    * @returns Message ID
    */
   async sendCardMessage(
     chatId: string,
     cardContent: BotCardContentBO,
+    receiveIdType = 'chat_id',
   ): Promise<BotMessageResponseBO> {
     try {
       const response = await this.client.sendMessage(
         chatId,
         cardContent,
         MessageType.INTERACTIVE,
+        receiveIdType,
       );
 
       if (response.code !== 0) {

--- a/src/services/bots/bot-service.ts
+++ b/src/services/bots/bot-service.ts
@@ -26,19 +26,19 @@ export class BotService {
   /**
    * Send text message to a chat
    *
-   * @param chatId - Chat ID
+   * @param receiveId - Receive ID
    * @param text - Message text
    * @param receiveIdType - Type of the receive ID, defaults to 'chat_id'
    * @returns Message ID
    */
   async sendTextMessage(
-    chatId: string,
+    receiveId: string,
     text: string,
     receiveIdType = 'chat_id',
   ): Promise<BotMessageResponseBO> {
     try {
       const response = await this.client.sendMessage(
-        chatId,
+        receiveId,
         text,
         MessageType.TEXT,
         receiveIdType,
@@ -72,19 +72,19 @@ export class BotService {
   /**
    * Send interactive card message
    *
-   * @param chatId - Chat ID
+   * @param receiveId - Receive ID
    * @param cardContent - Interactive card JSON content
    * @param receiveIdType - Type of the receive ID, defaults to 'chat_id'
    * @returns Message ID
    */
   async sendCardMessage(
-    chatId: string,
+    receiveId: string,
     cardContent: BotCardContentBO,
     receiveIdType = 'chat_id',
   ): Promise<BotMessageResponseBO> {
     try {
       const response = await this.client.sendMessage(
-        chatId,
+        receiveId,
         cardContent,
         MessageType.INTERACTIVE,
         receiveIdType,

--- a/tests/bot-client.test.js
+++ b/tests/bot-client.test.js
@@ -148,4 +148,25 @@ describe('BotClient', () => {
       );
     });
   });
+
+  describe('sendMessage with custom receive_id_type', () => {
+    it('should send a message with custom receive_id_type', async () => {
+      const userId = 'test_user_id';
+      const text = 'Hello, user!';
+      const msgType = MessageType.TEXT;
+      const receiveIdType = 'open_id';
+
+      await botClient.sendMessage(userId, text, msgType, receiveIdType);
+
+      expect(mockApiClient.post).toHaveBeenCalledWith(
+        '/open-apis/im/v1/messages',
+        {
+          receive_id: userId,
+          content: JSON.stringify({ text }),
+          msg_type: msgType,
+        },
+        { receive_id_type: receiveIdType },
+      );
+    });
+  });
 });

--- a/tests/bot-client.test.js
+++ b/tests/bot-client.test.js
@@ -31,13 +31,13 @@ const MockApiClient = jest.fn().mockImplementation(() => {
   };
 });
 
-jest.mock('../src/client/api-client.js', () => {
+jest.mock('../src/client/api-client', () => {
   return {
     ApiClient: MockApiClient,
   };
 });
 
-import { BotClient } from '../src/client/bots/bot-client.js';
+import { BotClient } from '../src/client/bots/bot-client';
 
 const MessageType = {
   TEXT: 'text',
@@ -57,16 +57,16 @@ describe('BotClient', () => {
 
   describe('sendMessage', () => {
     it('should send a text message with correct parameters including receive_id_type', async () => {
-      const chatId = 'test_chat_id';
+      const receiveId = 'test_chat_id';
       const text = 'Hello, world!';
       const msgType = MessageType.TEXT;
 
-      await botClient.sendMessage(chatId, text, msgType);
+      await botClient.sendMessage(receiveId, text, msgType);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         '/open-apis/im/v1/messages',
         {
-          receive_id: chatId,
+          receive_id: receiveId,
           content: JSON.stringify({ text }),
           msg_type: msgType,
         },
@@ -75,7 +75,7 @@ describe('BotClient', () => {
     });
 
     it('should send an interactive card message with correct parameters including receive_id_type', async () => {
-      const chatId = 'test_chat_id';
+      const receiveId = 'test_chat_id';
       const cardContent = {
         elements: [
           {
@@ -89,12 +89,12 @@ describe('BotClient', () => {
       };
       const msgType = MessageType.INTERACTIVE;
 
-      await botClient.sendMessage(chatId, cardContent, msgType);
+      await botClient.sendMessage(receiveId, cardContent, msgType);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         '/open-apis/im/v1/messages',
         {
-          receive_id: chatId,
+          receive_id: receiveId,
           content: JSON.stringify({ card: cardContent }),
           msg_type: msgType,
         },
@@ -103,7 +103,7 @@ describe('BotClient', () => {
     });
 
     it('should handle string card content correctly with receive_id_type parameter', async () => {
-      const chatId = 'test_chat_id';
+      const receiveId = 'test_chat_id';
       const cardContent = JSON.stringify({
         elements: [
           {
@@ -117,12 +117,12 @@ describe('BotClient', () => {
       });
       const msgType = MessageType.INTERACTIVE;
 
-      await botClient.sendMessage(chatId, cardContent, msgType);
+      await botClient.sendMessage(receiveId, cardContent, msgType);
 
       expect(mockApiClient.post).toHaveBeenCalledWith(
         '/open-apis/im/v1/messages',
         {
-          receive_id: chatId,
+          receive_id: receiveId,
           content: JSON.stringify({ card: JSON.parse(cardContent) }),
           msg_type: msgType,
         },


### PR DESCRIPTION
主要更改内容
1. API参数命名优化
将飞书MCP服务器中的参数命名与飞书API文档保持一致，主要更改是将chatId参数重命名为receiveId，以匹配飞书API中的receive_id参数。同时添加了receiveIdType参数支持多种接收者ID类型。

更改内容
客户端层: 更新了BotClient.sendMessage方法的参数命名，添加了receiveIdType参数支持
服务层: 更新了BotService.sendTextMessage和sendCardMessage方法的参数命名
工具层: 更新了TOOL_SEND_TEXT_MESSAGE和TOOL_SEND_CARD工具的参数命名
测试: 更新了bot-client.test.js中的测试用例
2. 项目文档更新
全面更新了项目README.md文档，添加了所有已实现API的详细说明：

搜索操作: 用户搜索、消息搜索、文档搜索
机器人操作: 发送消息、回复消息、编辑消息、转发消息等
聊天操作: 创建群聊、更新群聊、添加/移除成员等
文档操作: 获取、更新、删除文档等
多维表格操作: 创建、更新、删除记录等
用户操作: 获取用户信息、列表、搜索等
部门操作: 获取部门信息、列表等
日历操作: 获取日历列表、事件等
任务操作: 获取任务列表、创建任务等
优势
提高了代码与API文档的一致性
改善了MCP工具的可用性和可理解性
保持了参数命名的一致性，减少了混淆
完善了项目文档，便于开发者理解和使用